### PR TITLE
 Support for ES6 with latest frida-compile

### DIFF
--- a/package.json
+++ b/package.json
@@ -10,14 +10,19 @@
         {
           "presets": [
             [
-              "es2015",
+              "@babel/preset-env",
               {
                 "loose": true
               }
             ]
           ],
           "plugins": [
-            "transform-runtime"
+            [
+              "@babel/plugin-transform-runtime",
+              {
+                "corejs": 2
+              }
+            ]
           ]
         }
       ]
@@ -33,9 +38,9 @@
   },
   "homepage": "https://github.com/frida/frida-objc#readme",
   "dependencies": {
-    "babel-plugin-transform-runtime": "^6.15.0",
-    "babel-preset-es2015": "^6.18.0",
-    "babel-runtime": "^6.20.0",
-    "babelify": "^7.3.0"
+    "@babel/core": "^7.1.2",
+    "@babel/plugin-transform-runtime": "^7.1.0",
+    "@babel/preset-env": "^7.1.0",
+    "@babel/runtime-corejs2": "^7.1.2"
   }
 }


### PR DESCRIPTION
Using the project as-is wasn't allowing use of ES6 syntax to parse result of `enumerateTypesSync()` in agent code. This change is based on transformations setup from https://github.com/oleavr/frida-agent-example and allows you to do that.